### PR TITLE
Feature/cube

### DIFF
--- a/components/SetSelector.tsx
+++ b/components/SetSelector.tsx
@@ -21,6 +21,7 @@ const SET_LABELS: Record<MagicSet, string> = {
   [MagicSet.DOMINARIA]: "Dominaria",
   [MagicSet.AMONKHET]: "Amonkhet",
   [MagicSet.KALADESH]: "Kaladesh",
+  [MagicSet.ARENA_CUBE]: "Arena Cube",
 };
 
 const SetSelect = styled(Select)`

--- a/lib/cards.ts
+++ b/lib/cards.ts
@@ -85,6 +85,9 @@ async function getApiCards(set: MagicSet, deck: Deck): Promise<ApiCard[]> {
 async function fetchApiCards(set: MagicSet, deck: Deck): Promise<ApiCard[]> {
   const endDate = new Date().toISOString().substring(0, 10);
   let url = `https://www.17lands.com/card_ratings/data?expansion=${set}&format=PremierDraft&start_date=2020-04-16&end_date=${endDate}`;
+  if (set == MagicSet.ARENA_CUBE) {
+    url = `https://www.17lands.com/card_ratings/data?expansion=${set}&format=PremierDraft&start_date=2022-01-01&end_date=${endDate}`;
+  }
   if (deck !== Deck.ALL) {
     url = url.concat(`&colors=${deck}`);
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,6 +12,7 @@ export enum MagicSet {
   DOMINARIA = "dom",
   AMONKHET = "akr",
   KALADESH = "klr",
+  ARENA_CUBE = "cube",
 }
 
 export enum Deck {


### PR DESCRIPTION
This adds the current arena cube at the bottom of the dropdown. I wanted to use this for myself, and saw it also mentioned in #2

Some known improvements to this could be:
- Hide rarity for cube since it doesn't matter
- Use the alchemy version of cards like A-Luminarch Aspirant
- Better logic for setting the most recent cube changes as the start date instead of hardcoding 2022-01-01
- Consider moving away from 2-color filters toward something more realistic for the format

But I figured I'd get a PR open in case it's helpful. Feel free to close out or copy over and edit or whatever is easiest - since this is convenient to run locally, I'm happy with anything!