### PR TITLE
test: intentionally break extractUrlQuery test

### DIFF
--- a/test/lib/util.test.ts
+++ b/test/lib/util.test.ts
@@ -3,7 +3,7 @@ import { extractUrlQuery } from "lib/util";
 describe("extractUrlQuery", () => {
   it("extracts the  query string", () => {
     expect(extractUrlQuery("/mid?deck=wr&rarity=crm")).toEqual(
-      "deck=wr&rarity=crm"
+      "wrong-expected-value"
     );
   });
   it("works on empty query strings", () => {


### PR DESCRIPTION
This PR intentionally breaks the `extractUrlQuery` unit test by changing the expected value to `'wrong-expected-value'`.